### PR TITLE
Moved .reset-filter() to the end of declaration

### DIFF
--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -112,8 +112,8 @@
     text-decoration: none;
     background-color: transparent;
     background-image: none; // Remove CSS gradient
-    .reset-filter();
     cursor: @cursor-disabled;
+    .reset-filter();
   }
 }
 


### PR DESCRIPTION
This is a fix for Safari's warnings (`Unexpected CSS token: :`) for the line produced by `reset-filter` mixin.
